### PR TITLE
Pyhton 3.11 / 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       # respecting GitHub's concurrent jobs limit.
       max-parallel: 1
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.7'] # 3.8 first, it has "all the tox envs"
+        python-version: ['3.8', '3.9', '3.10', '3.11'] # 3.8 first, it has "all the tox envs"
     steps:
       - uses: actions/checkout@v3.5.3
       - name: Setup Python

--- a/.pylintrc
+++ b/.pylintrc
@@ -55,7 +55,7 @@ persistent=yes
 
 # Min Python version to use for version dependend checks. Will default to the
 # version used to run pylint.
-py-version=3.7
+py-version=3.8
 
 # When enabled, pylint would attempt to guess common misconfiguration and emit
 # user-friendly hints instead of false-positive error messages.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -121,7 +121,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 3.7 up to 3.10. Check
+3. The pull request should work for Python 3.8 up to 3.11. Check
    the pull request status and make sure that the tests pass for all
    supported Python versions.
 

--- a/requirements_basedev.txt
+++ b/requirements_basedev.txt
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-# Base dev dependencies, compatible with Python 3.7+
+# Base dev dependencies, compatible with Python 3.8+
 -r requirements.txt
 assertpy==1.1
 bump2version==1.0.1

--- a/setup.py
+++ b/setup.py
@@ -42,17 +42,17 @@ requirements = [
 setup(
     author="Ryan Murray",
     author_email="nessie-release-builder@dremio.com",
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     description="Project Nessie: Transactional Catalog for Data Lakes with Git-like semantics",
     entry_points={

--- a/tox.ini
+++ b/tox.ini
@@ -15,15 +15,15 @@
 #
 
 [tox]
-envlist = py37, py38, py39, py310, format, lint, safety, docs, docs_sync_check
+envlist = py38, py39, py310, py311, format, lint, safety, docs, docs_sync_check
 
 [gh-actions]
 python =
-    3.7: py37
     # docs needs to run before docs_sync_check
     3.8: py38, lint, safety, docs, docs_sync_check
     3.9: py39
     3.10: py310
+    3.11: py311
 
 
 [testenv:format]


### PR DESCRIPTION
Python 3.7 is EOL, removing it from CI.
Adding Python 3.11 to CI.