### PR TITLE
Fix unencoded url components

### DIFF
--- a/pynessie/client/_endpoints.py
+++ b/pynessie/client/_endpoints.py
@@ -17,7 +17,7 @@
 
 import os
 from typing import Any, Optional, Union, cast
-from urllib.parse import quote_plus
+from urllib.parse import quote
 
 import requests
 import simplejson as jsonlib
@@ -42,6 +42,10 @@ def _get_headers(has_body: bool = False) -> dict:
     if has_body:
         headers = {"Content-Type": "application/json"}
     return headers
+
+
+def _sanitize_url(url: str, *args: str) -> str:
+    return url.format(*[quote(arg, safe="") for arg in args])
 
 
 def _get(
@@ -124,10 +128,11 @@ def all_references(base_url: str, auth: Optional[AuthBase], ssl_verify: bool = T
     :param fetch_all: indicates whether additional metadata should be fetched
     :return: json list of Nessie references
     """
+    url = _sanitize_url(base_url + "/trees")
     params = {}
     if fetch_all:
         params["fetch"] = "ALL"
-    return cast(dict, _get(base_url + "/trees", auth, ssl_verify=ssl_verify, params=params))
+    return cast(dict, _get(url, auth, ssl_verify=ssl_verify, params=params))
 
 
 def get_reference(base_url: str, auth: Optional[AuthBase], ref: str, ssl_verify: bool = True) -> dict:
@@ -139,7 +144,8 @@ def get_reference(base_url: str, auth: Optional[AuthBase], ref: str, ssl_verify:
     :param ssl_verify: ignore ssl errors if False
     :return: json Nessie branch or tag
     """
-    return cast(dict, _get(base_url + "/trees/tree/{}".format(quote_plus(ref)), auth, ssl_verify=ssl_verify))
+    url = _sanitize_url(base_url + "/trees/tree/{}", ref)
+    return cast(dict, _get(url, auth, ssl_verify=ssl_verify))
 
 
 def create_reference(
@@ -154,10 +160,11 @@ def create_reference(
     :param ssl_verify: ignore ssl errors if False
     :return: json Nessie branch or tag
     """
+    url = _sanitize_url(base_url + "/trees/tree")
     params = {}
     if source_ref:
         params["sourceRefName"] = source_ref
-    return cast(dict, _post(base_url + "/trees/tree", auth, ref_json, ssl_verify=ssl_verify, params=params))
+    return cast(dict, _post(url, auth, ref_json, ssl_verify=ssl_verify, params=params))
 
 
 def get_default_branch(base_url: str, auth: Optional[AuthBase], ssl_verify: bool = True) -> dict:
@@ -168,7 +175,8 @@ def get_default_branch(base_url: str, auth: Optional[AuthBase], ssl_verify: bool
     :param ssl_verify: ignore ssl errors if False
     :return: json Nessie branch
     """
-    return cast(dict, _get(base_url + "/trees/tree", auth, ssl_verify=ssl_verify))
+    url = _sanitize_url(base_url + "/trees/tree")
+    return cast(dict, _get(url, auth, ssl_verify=ssl_verify))
 
 
 def delete_branch(base_url: str, auth: Optional[AuthBase], branch: str, hash_: str, ssl_verify: bool = True) -> None:
@@ -180,8 +188,9 @@ def delete_branch(base_url: str, auth: Optional[AuthBase], branch: str, hash_: s
     :param hash_: branch hash
     :param ssl_verify: ignore ssl errors if False
     """
+    url = _sanitize_url(base_url + "/trees/branch/{}", branch)
     params = {"expectedHash": hash_}
-    _delete(base_url + "/trees/branch/{}".format(quote_plus(branch)), auth, ssl_verify=ssl_verify, params=params)
+    _delete(url, auth, ssl_verify=ssl_verify, params=params)
 
 
 def delete_tag(base_url: str, auth: Optional[AuthBase], tag: str, hash_: str, ssl_verify: bool = True) -> None:
@@ -193,8 +202,9 @@ def delete_tag(base_url: str, auth: Optional[AuthBase], tag: str, hash_: str, ss
     :param hash_: tag hash
     :param ssl_verify: ignore ssl errors if False
     """
+    url = _sanitize_url(base_url + "/trees/tag/{}", tag)
     params = {"expectedHash": hash_}
-    _delete(base_url + "/trees/tag/{}".format(quote_plus(tag)), auth, ssl_verify=ssl_verify, params=params)
+    _delete(url, auth, ssl_verify=ssl_verify, params=params)
 
 
 def list_tables(
@@ -219,6 +229,7 @@ def list_tables(
     :param ssl_verify: ignore ssl errors if False
     :return: json list of Nessie table names
     """
+    url = _sanitize_url(base_url + "/trees/tree/{}/entries", ref)
     params = {}
     if max_result_hint:
         params["maxRecords"] = str(max_result_hint)
@@ -228,7 +239,7 @@ def list_tables(
         params["pageToken"] = page_token
     if query_filter:
         params["filter"] = query_filter
-    return cast(list, _get(base_url + "/trees/tree/{}/entries".format(quote_plus(ref)), auth, ssl_verify=ssl_verify, params=params))
+    return cast(list, _get(url, auth, ssl_verify=ssl_verify, params=params))
 
 
 def list_logs(
@@ -253,6 +264,7 @@ def list_logs(
     :param filtering_args: All of the args used to filter the log
     :return: json dict of Nessie logs
     """
+    url = _sanitize_url(base_url + "/trees/tree/{}/log", ref)
     params = filtering_args
     if hash_on_ref:
         params["hashOnRef"] = hash_on_ref
@@ -260,7 +272,7 @@ def list_logs(
         params["maxRecords"] = max_records
     if fetch_all:
         params["fetch"] = "ALL"
-    return cast(dict, _get(base_url + "/trees/tree/{}/log".format(quote_plus(ref)), auth, ssl_verify=ssl_verify, params=filtering_args))
+    return cast(dict, _get(url, auth, ssl_verify=ssl_verify, params=filtering_args))
 
 
 def get_content(
@@ -276,12 +288,11 @@ def get_content(
     :param ssl_verify: ignore ssl errors if False
     :return: json dict of Nessie table
     """
+    url = _sanitize_url(base_url + "/contents/{}", content_key.to_path_string())
     params = {"ref": ref}
     if hash_on_ref:
         params["hashOnRef"] = hash_on_ref
-    return cast(
-        dict, _get(base_url + "/contents/{}".format(quote_plus(content_key.to_path_string())), auth, ssl_verify=ssl_verify, params=params)
-    )
+    return cast(dict, _get(url, auth, ssl_verify=ssl_verify, params=params))
 
 
 def assign_branch(
@@ -296,9 +307,9 @@ def assign_branch(
     :param old_hash: current hash of the branch
     :param ssl_verify: ignore ssl errors if False
     """
-    url = "/trees/branch/{}".format(quote_plus(branch))
+    url = _sanitize_url(base_url + "/trees/branch/{}", branch)
     params = {"expectedHash": old_hash}
-    _put(base_url + url, auth, assign_to_json, ssl_verify=ssl_verify, params=params)
+    _put(url, auth, assign_to_json, ssl_verify=ssl_verify, params=params)
 
 
 def assign_tag(
@@ -313,9 +324,9 @@ def assign_tag(
     :param old_hash: current hash of the tag
     :param ssl_verify: ignore ssl errors if False
     """
-    url = "/trees/tag/{}".format(quote_plus(tag))
+    url = _sanitize_url(base_url + "/trees/tag/{}", tag)
     params = {"expectedHash": old_hash}
-    _put(base_url + url, auth, assign_to_json, ssl_verify=ssl_verify, params=params)
+    _put(url, auth, assign_to_json, ssl_verify=ssl_verify, params=params)
 
 
 def cherry_pick(
@@ -330,11 +341,11 @@ def cherry_pick(
     :param expected_hash: expected hash of HEAD of branch
     :param ssl_verify: ignore ssl errors if False
     """
-    url = "/trees/branch/{}/transplant".format(quote_plus(branch))
+    url = _sanitize_url(base_url + "/trees/branch/{}/transplant", branch)
     params = {}
     if expected_hash:
         params["expectedHash"] = expected_hash
-    response = _post(base_url + url, auth, json=transplant_json, ssl_verify=ssl_verify, params=params)
+    response = _post(url, auth, json=transplant_json, ssl_verify=ssl_verify, params=params)
     return cast(dict, response)
 
 
@@ -351,11 +362,11 @@ def merge(
     :param ssl_verify: ignore ssl errors if False
     :return: json dict of a merge response
     """
-    url = "/trees/branch/{}/merge".format(quote_plus(branch))
+    url = _sanitize_url(base_url + "/trees/branch/{}/merge", branch)
     params = {}
     if expected_hash:
         params["expectedHash"] = expected_hash
-    response = _post(base_url + url, auth, json=merge_json, ssl_verify=ssl_verify, params=params)
+    response = _post(url, auth, json=merge_json, ssl_verify=ssl_verify, params=params)
     return cast(dict, response)
 
 
@@ -376,9 +387,9 @@ def commit(
     :param expected_hash: expected hash of HEAD of branch
     :param ssl_verify: ignore ssl errors if False
     """
-    url = "/trees/branch/{}/commit".format(quote_plus(branch))
+    url = _sanitize_url(base_url + "/trees/branch/{}/commit", branch)
     params = {"expectedHash": expected_hash}
-    return cast(dict, _post(base_url + url, auth, json=operations, ssl_verify=ssl_verify, params=params))
+    return cast(dict, _post(url, auth, json=operations, ssl_verify=ssl_verify, params=params))
 
 
 def get_diff(
@@ -403,7 +414,5 @@ def get_diff(
     """
     from_hash_on_ref_asterisk = f"*{from_hash_on_ref}" if from_hash_on_ref else ""
     to_hash_on_ref_asterisk = f"*{to_hash_on_ref}" if to_hash_on_ref else ""
-    return cast(
-        dict,
-        _get(f"{base_url}/diffs/{from_ref}{from_hash_on_ref_asterisk}...{to_ref}{to_hash_on_ref_asterisk}", auth, ssl_verify=ssl_verify),
-    )
+    url = _sanitize_url(base_url + "/diffs/{}{}...{}{}", from_ref, from_hash_on_ref_asterisk, to_ref, to_hash_on_ref_asterisk)
+    return cast(dict, _get(url, auth, ssl_verify=ssl_verify))

--- a/pynessie/client/_endpoints.py
+++ b/pynessie/client/_endpoints.py
@@ -17,6 +17,7 @@
 
 import os
 from typing import Any, Optional, Union, cast
+from urllib.parse import quote_plus
 
 import requests
 import simplejson as jsonlib
@@ -138,7 +139,7 @@ def get_reference(base_url: str, auth: Optional[AuthBase], ref: str, ssl_verify:
     :param ssl_verify: ignore ssl errors if False
     :return: json Nessie branch or tag
     """
-    return cast(dict, _get(base_url + "/trees/tree/{}".format(ref), auth, ssl_verify=ssl_verify))
+    return cast(dict, _get(base_url + "/trees/tree/{}".format(quote_plus(ref)), auth, ssl_verify=ssl_verify))
 
 
 def create_reference(
@@ -180,7 +181,7 @@ def delete_branch(base_url: str, auth: Optional[AuthBase], branch: str, hash_: s
     :param ssl_verify: ignore ssl errors if False
     """
     params = {"expectedHash": hash_}
-    _delete(base_url + "/trees/branch/{}".format(branch), auth, ssl_verify=ssl_verify, params=params)
+    _delete(base_url + "/trees/branch/{}".format(quote_plus(branch)), auth, ssl_verify=ssl_verify, params=params)
 
 
 def delete_tag(base_url: str, auth: Optional[AuthBase], tag: str, hash_: str, ssl_verify: bool = True) -> None:
@@ -193,7 +194,7 @@ def delete_tag(base_url: str, auth: Optional[AuthBase], tag: str, hash_: str, ss
     :param ssl_verify: ignore ssl errors if False
     """
     params = {"expectedHash": hash_}
-    _delete(base_url + "/trees/tag/{}".format(tag), auth, ssl_verify=ssl_verify, params=params)
+    _delete(base_url + "/trees/tag/{}".format(quote_plus(tag)), auth, ssl_verify=ssl_verify, params=params)
 
 
 def list_tables(
@@ -227,7 +228,7 @@ def list_tables(
         params["pageToken"] = page_token
     if query_filter:
         params["filter"] = query_filter
-    return cast(list, _get(base_url + "/trees/tree/{}/entries".format(ref), auth, ssl_verify=ssl_verify, params=params))
+    return cast(list, _get(base_url + "/trees/tree/{}/entries".format(quote_plus(ref)), auth, ssl_verify=ssl_verify, params=params))
 
 
 def list_logs(
@@ -259,7 +260,7 @@ def list_logs(
         params["maxRecords"] = max_records
     if fetch_all:
         params["fetch"] = "ALL"
-    return cast(dict, _get(base_url + "/trees/tree/{}/log".format(ref), auth, ssl_verify=ssl_verify, params=filtering_args))
+    return cast(dict, _get(base_url + "/trees/tree/{}/log".format(quote_plus(ref)), auth, ssl_verify=ssl_verify, params=filtering_args))
 
 
 def get_content(
@@ -278,7 +279,9 @@ def get_content(
     params = {"ref": ref}
     if hash_on_ref:
         params["hashOnRef"] = hash_on_ref
-    return cast(dict, _get(base_url + "/contents/{}".format(content_key.to_path_string()), auth, ssl_verify=ssl_verify, params=params))
+    return cast(
+        dict, _get(base_url + "/contents/{}".format(quote_plus(content_key.to_path_string())), auth, ssl_verify=ssl_verify, params=params)
+    )
 
 
 def assign_branch(
@@ -293,7 +296,7 @@ def assign_branch(
     :param old_hash: current hash of the branch
     :param ssl_verify: ignore ssl errors if False
     """
-    url = "/trees/branch/{}".format(branch)
+    url = "/trees/branch/{}".format(quote_plus(branch))
     params = {"expectedHash": old_hash}
     _put(base_url + url, auth, assign_to_json, ssl_verify=ssl_verify, params=params)
 
@@ -310,7 +313,7 @@ def assign_tag(
     :param old_hash: current hash of the tag
     :param ssl_verify: ignore ssl errors if False
     """
-    url = "/trees/tag/{}".format(tag)
+    url = "/trees/tag/{}".format(quote_plus(tag))
     params = {"expectedHash": old_hash}
     _put(base_url + url, auth, assign_to_json, ssl_verify=ssl_verify, params=params)
 
@@ -327,7 +330,7 @@ def cherry_pick(
     :param expected_hash: expected hash of HEAD of branch
     :param ssl_verify: ignore ssl errors if False
     """
-    url = "/trees/branch/{}/transplant".format(branch)
+    url = "/trees/branch/{}/transplant".format(quote_plus(branch))
     params = {}
     if expected_hash:
         params["expectedHash"] = expected_hash
@@ -348,7 +351,7 @@ def merge(
     :param ssl_verify: ignore ssl errors if False
     :return: json dict of a merge response
     """
-    url = "/trees/branch/{}/merge".format(branch)
+    url = "/trees/branch/{}/merge".format(quote_plus(branch))
     params = {}
     if expected_hash:
         params["expectedHash"] = expected_hash
@@ -373,7 +376,7 @@ def commit(
     :param expected_hash: expected hash of HEAD of branch
     :param ssl_verify: ignore ssl errors if False
     """
-    url = "/trees/branch/{}/commit".format(branch)
+    url = "/trees/branch/{}/commit".format(quote_plus(branch))
     params = {"expectedHash": expected_hash}
     return cast(dict, _post(base_url + url, auth, json=operations, ssl_verify=ssl_verify, params=params))
 

--- a/tests/test_nessie_cli.py
+++ b/tests/test_nessie_cli.py
@@ -293,39 +293,41 @@ def test_tag() -> None:
 
 
 @pytest.mark.nessieserver
-def test_assign() -> None:
+@pytest.mark.parametrize("branch", [("dev"), ("branch/name"), ("branch/name_env-dev.1")])
+def test_assign(branch: str) -> None:
     """Test assign operation."""
-    execute_cli_command(["branch", "dev"])
-    make_commit("assign_foo_bar", _new_table(), "dev")
-    execute_cli_command(["branch", "main", "dev", "--force"])
+    execute_cli_command(["branch", branch])
+    make_commit("assign_foo_bar", _new_table(), branch)
+    execute_cli_command(["branch", "main", branch, "--force"])
     branches = ReferenceSchema().loads(execute_cli_command(["--json", "branch"]), many=True)
     refs = {i.name: i.hash_ for i in branches}
-    assert refs["main"] == refs["dev"]
+    assert refs["main"] == refs[branch]
     execute_cli_command(["tag", "v1.0", "main"])
     tags = {i.name: i.hash_ for i in ReferenceSchema().loads(execute_cli_command(["--json", "tag"]), many=True)}
     assert tags["v1.0"] == refs["main"]
-    execute_cli_command(["tag", "v1.0", "dev", "--force"])
+    execute_cli_command(["tag", "v1.0", branch, "--force"])
     tags = {i.name: i.hash_ for i in ReferenceSchema().loads(execute_cli_command(["--json", "tag"]), many=True)}
-    assert tags["v1.0"] == refs["dev"]
+    assert tags["v1.0"] == refs[branch]
 
 
 @pytest.mark.nessieserver
-def test_merge() -> None:
+@pytest.mark.parametrize("branch", [("dev"), ("branch/name"), ("branch/name_env-dev.1")])
+def test_merge(branch: str) -> None:
     """Test merge operation."""
     make_commit("initial_commit", _new_table(), "main", message="Initial commit")
     initial_hash = ref_hash("main")
-    execute_cli_command(["branch", "dev"])
-    make_commit("merge_foo_bar", _new_table(), "dev")
+    execute_cli_command(["branch", branch])
+    make_commit("merge_foo_bar", _new_table(), branch)
     main_hash = ref_hash("main")
-    dev_hash = ref_hash("dev")
+    branch_hash = ref_hash(branch)
 
-    merge_output = execute_cli_command(["merge", "dev", "-c", main_hash])
+    merge_output = execute_cli_command(["merge", branch, "-c", main_hash])
 
     branches = ReferenceSchema().loads(execute_cli_command(["--json", "branch"]), many=True)
     refs = {i.name: i.hash_ for i in branches}
 
     expected_output_list = [
-        f"Merged dev onto main (was on {main_hash} before merge)",
+        f"Merged {branch} onto main (was on {main_hash} before merge)",
         f"Identified merge base commit {initial_hash}",
         f"Resultant hash on main after merge: {refs['main']}",
     ]
@@ -333,10 +335,10 @@ def test_merge() -> None:
 
     # If we try to merge again from dev to main we get an error.
     # This is because there is nothing more to merge.
-    merge_output = execute_cli_command(["merge", "dev", "-c", refs["main"]])
+    merge_output = execute_cli_command(["merge", branch, "-c", refs["main"]])
     expected_output_list = [
-        f"Nothing merged from dev onto main (still on {refs['main']})",
-        f"Identified merge base commit {dev_hash}",
+        f"Nothing merged from {branch} onto main (still on {refs['main']})",
+        f"Identified merge base commit {branch_hash}",
         f"Current, unchanged hash on main after merge: {refs['main']}",
     ]
     assert_that(merge_output.splitlines()).is_equal_to(expected_output_list)
@@ -345,24 +347,25 @@ def test_merge() -> None:
     # we don't check for equality of hashes here because a merge
     # produces a different commit hash on the target branch
     assert_that(logs).is_length(2)
-    assert_that(logs[0]["message"]).starts_with("Merged dev at ")
-    logs = simplejson.loads(execute_cli_command(["--json", "log", "dev"]))
+    assert_that(logs[0]["message"]).starts_with(f"Merged {branch} at ")
+    logs = simplejson.loads(execute_cli_command(["--json", "log", branch]))
     assert_that(logs).is_length(2)
 
 
 @pytest.mark.nessieserver
-def test_merge_json() -> None:
+@pytest.mark.parametrize("branch", [("dev"), ("branch/name"), ("branch/name_env-dev.1")])
+def test_merge_json(branch: str) -> None:
     """Test merge operation."""
     make_commit("initial_commit", _new_table(), "main", message="Initial commit")
-    execute_cli_command(["branch", "dev"])
-    make_commit("merge_foo_bar", _new_table(), "dev")
+    execute_cli_command(["branch", branch])
+    make_commit("merge_foo_bar", _new_table(), branch)
     main_hash = ref_hash("main")
-    dev_hash = ref_hash("dev")
+    branch_hash = ref_hash(branch)
 
     # Passing detached commit-id plus a _different_ hash-on-ref --> error
-    execute_cli_command(["merge", f"dev@{dev_hash}", "-c", main_hash, "-o", main_hash], ret_val=1)
+    execute_cli_command(["merge", f"{branch}@{branch_hash}", "-c", main_hash, "-o", main_hash], ret_val=1)
 
-    merge_output = execute_cli_command(["--json", "merge", "dev", "-c", main_hash])
+    merge_output = execute_cli_command(["--json", "merge", branch, "-c", main_hash])
     merge_response = MergeResponseSchema().loads(merge_output)
 
     # Check merge response
@@ -375,31 +378,32 @@ def test_merge_json() -> None:
     # we don't check for equality of hashes here because a merge
     # produces a different commit hash on the target branch
     assert_that(logs).is_length(2)
-    assert_that(logs[0]["message"]).starts_with("Merged dev at ")
-    logs = simplejson.loads(execute_cli_command(["--json", "log", "dev"]))
+    assert_that(logs[0]["message"]).starts_with(f"Merged {branch} at ")
+    logs = simplejson.loads(execute_cli_command(["--json", "log", branch]))
     assert_that(logs).is_length(2)
 
 
 @pytest.mark.nessieserver
-def test_merge_detached() -> None:
+@pytest.mark.parametrize("branch", [("dev"), ("branch/name"), ("branch/name_env-dev.1")])
+def test_merge_detached(branch: str) -> None:
     """Test merge operation."""
     make_commit("initial_commit", _new_table(), "main", message="Initial commit")
     initial_hash = ref_hash("main")
-    execute_cli_command(["branch", "dev"])
-    make_commit("merge_foo_bar", _new_table(), "dev")
+    execute_cli_command(["branch", branch])
+    make_commit("merge_foo_bar", _new_table(), branch)
     main_hash = ref_hash("main")
-    dev_hash = ref_hash("dev")
+    branch_hash = ref_hash(branch)
 
     # Passing detached commit-id plus a _different_ hash-on-ref --> error
-    execute_cli_command(["merge", dev_hash, "-c", main_hash, "-o", main_hash], ret_val=1)
+    execute_cli_command(["merge", branch_hash, "-c", main_hash, "-o", main_hash], ret_val=1)
 
-    merge_output = execute_cli_command(["merge", "dev", "-c", main_hash])
+    merge_output = execute_cli_command(["merge", branch, "-c", main_hash])
 
     branches = ReferenceSchema().loads(execute_cli_command(["--json", "branch"]), many=True)
     refs = {i.name: i.hash_ for i in branches}
 
     expected_output_list = [
-        f"Merged dev onto main (was on {main_hash} before merge)",
+        f"Merged {branch} onto main (was on {main_hash} before merge)",
         f"Identified merge base commit {initial_hash}",
         f"Resultant hash on main after merge: {refs['main']}",
     ]
@@ -409,24 +413,25 @@ def test_merge_detached() -> None:
     # we don't check for equality of hashes here because a merge
     # produces a different commit hash on the target branch
     assert_that(logs).is_length(2)
-    assert_that(logs[0]["message"]).starts_with("Merged dev at ")
-    logs = simplejson.loads(execute_cli_command(["--json", "log", "dev"]))
+    assert_that(logs[0]["message"]).starts_with(f"Merged {branch} at ")
+    logs = simplejson.loads(execute_cli_command(["--json", "log", branch]))
     assert_that(logs).is_length(2)
 
 
 @pytest.mark.nessieserver
-def test_merge_detached_json() -> None:
+@pytest.mark.parametrize("branch", [("dev"), ("branch/name"), ("branch/name_env-dev.1")])
+def test_merge_detached_json(branch: str) -> None:
     """Test merge operation."""
     make_commit("initial_commit", _new_table(), "main", message="Initial commit")
-    execute_cli_command(["branch", "dev"])
-    make_commit("merge_foo_bar", _new_table(), "dev")
+    execute_cli_command(["branch", branch])
+    make_commit("merge_foo_bar", _new_table(), branch)
     main_hash = ref_hash("main")
-    dev_hash = ref_hash("dev")
+    branch_hash = ref_hash(branch)
 
     # Passing detached commit-id plus a _different_ hash-on-ref --> error
-    execute_cli_command(["merge", dev_hash, "-c", main_hash, "-o", main_hash], ret_val=1)
+    execute_cli_command(["merge", branch_hash, "-c", main_hash, "-o", main_hash], ret_val=1)
 
-    merge_output = execute_cli_command(["--json", "merge", dev_hash, "-c", main_hash])
+    merge_output = execute_cli_command(["--json", "merge", branch_hash, "-c", main_hash])
     merge_response = MergeResponseSchema().loads(merge_output)
 
     # Check merge response
@@ -440,21 +445,22 @@ def test_merge_detached_json() -> None:
     # produces a different commit hash on the target branch
     assert_that(logs).is_length(2)
     assert_that(logs[0]["message"]).starts_with("Merged DETACHED at ")
-    logs = simplejson.loads(execute_cli_command(["--json", "log", "dev"]))
+    logs = simplejson.loads(execute_cli_command(["--json", "log", branch]))
     assert_that(logs).is_length(2)
 
 
 @pytest.mark.nessieserver
-def test_transplant() -> None:
+@pytest.mark.parametrize("branch", [("dev"), ("branch/name"), ("branch/name_env-dev.1")])
+def test_transplant(branch: str) -> None:
     """Test transplant operation."""
-    execute_cli_command(["branch", "dev"])
-    make_commit("transplant_foo_bar", _new_table(), "dev", message="commit 1")
-    make_commit("bar_bar", _new_table(), "dev", message="commit 2")
-    make_commit("foo_baz", _new_table(), "dev", message="commit 3")
+    execute_cli_command(["branch", branch])
+    make_commit("transplant_foo_bar", _new_table(), branch, message="commit 1")
+    make_commit("bar_bar", _new_table(), branch, message="commit 2")
+    make_commit("foo_baz", _new_table(), branch, message="commit 3")
     main_hash = ref_hash("main")
-    logs = simplejson.loads(execute_cli_command(["--json", "log", "dev"]))
+    logs = simplejson.loads(execute_cli_command(["--json", "log", branch]))
     first_hash = [i["hash"] for i in logs]
-    merge_output = execute_cli_command(["cherry-pick", "-c", main_hash, "-s", "dev", first_hash[1], first_hash[0]])
+    merge_output = execute_cli_command(["cherry-pick", "-c", main_hash, "-s", branch, first_hash[1], first_hash[0]])
 
     branches = ReferenceSchema().loads(execute_cli_command(["--json", "branch"]), many=True)
     refs = {i.name: i.hash_ for i in branches}
@@ -472,16 +478,15 @@ def test_transplant() -> None:
 
 
 @pytest.mark.nessieserver
-def test_diff() -> None:
+@pytest.mark.parametrize("branch,content_key", [("dev_test_diff", "diff_foo_dev"), ("dev/test/diff", "diff/foo/bar")])
+def test_diff(branch: str, content_key: str) -> None:
     """Test log and log filtering."""
     diff = DiffResponseSchema().loads(execute_cli_command(["--json", "diff", "main", "main"]))
     main_hash = ref_hash("main")
     assert_that(diff).is_not_none()
     assert_that(diff.diffs).is_empty()
-    branch = "dev_test_diff"
     execute_cli_command(["branch", branch])
     table = _new_table()
-    content_key = "diff_foo_dev"
     make_commit(content_key, table, branch, author="nessie_user1")
     branch_hash = ref_hash(branch)
 

--- a/tests/test_nessie_cli.py
+++ b/tests/test_nessie_cli.py
@@ -209,6 +209,9 @@ def test_branch() -> None:
     execute_cli_command(["branch", "etl_hash", f"main@{main_hash}"])
     references = ReferenceSchema().loads(execute_cli_command(["--json", "branch"]), many=True)
     assert len(references) == 5
+    execute_cli_command(["branch", "with/slash", f"main@{main_hash}"])
+    references = ReferenceSchema().loads(execute_cli_command(["--json", "branch"]), many=True)
+    assert len(references) == 6
     references = ReferenceSchema().loads(execute_cli_command(["--json", "branch", "-l", "etl"]), many=False)
     assert_that(references.name).is_equal_to("etl")
     references = simplejson.loads(execute_cli_command(["--json", "branch", "-l", "foo"]))
@@ -232,6 +235,7 @@ def test_branch() -> None:
     execute_cli_command(["branch", "-d", "dev", "-c", dev_hash])
     execute_cli_command(["branch", "-d", "etl_hash", "-c", main_hash])
     execute_cli_command(["branch", "-d", "dev_hash"])
+    execute_cli_command(["branch", "-d", "with/slash"])
     references = ReferenceSchema().loads(execute_cli_command(["--json", "branch"]), many=True)
     assert len(references) == 1
 
@@ -255,6 +259,9 @@ def test_tag() -> None:
     execute_cli_command(["tag", "etl-hash-tag", f"main@{main_hash}"])
     references = ReferenceSchema().loads(execute_cli_command(["--json", "tag"]), many=True)
     assert len(references) == 4
+    execute_cli_command(["tag", "with/slash/tag", f"main@{main_hash}"])
+    references = ReferenceSchema().loads(execute_cli_command(["--json", "tag"]), many=True)
+    assert len(references) == 5
     references = ReferenceSchema().loads(execute_cli_command(["--json", "tag", "-l", "etl-tag"]), many=False)
     assert_that(references.name).is_equal_to("etl-tag")
     references = simplejson.loads(execute_cli_command(["--json", "tag", "-l", "foo"]))
@@ -263,6 +270,7 @@ def test_tag() -> None:
     execute_cli_command(["tag", "-d", "etl-hash-tag"])
     execute_cli_command(["tag", "-d", "dev-tag", "-c", main_hash])
     execute_cli_command(["tag", "-d", "dev-hash-tag", "-c", main_hash])
+    execute_cli_command(["tag", "-d", "with/slash/tag", "-c", main_hash])
     references = ReferenceSchema().loads(execute_cli_command(["--json", "tag"]), many=True)
     assert len(references) == 0
     execute_cli_command(["tag", "v1.0"])

--- a/tests/test_nessie_client.py
+++ b/tests/test_nessie_client.py
@@ -52,8 +52,8 @@ def test_client_interface_e2e() -> None:
         assert create_branch_ref == reference
         assert isinstance(reference.hash_, str)
         tables = client.list_keys(reference.name, reference.hash_)
-    assert isinstance(tables, Entries)
-    assert len(tables.entries) == 0
+        assert isinstance(tables, Entries)
+        assert len(tables.entries) == 0
     assert isinstance(main_commit, str)
     client.delete_branch("test", main_commit)
     references = client.list_references().references
@@ -68,10 +68,10 @@ def test_client_sanitize_url() -> None:
     client = init()
     base_url = client.get_base_url()
     assert _sanitize_url(base_url) == base_url
-    assert _sanitize_url(base_url + "trees/tree") == base_url + "trees/tree"
-    assert _sanitize_url(base_url + "trees/tree/{}", "my tag with spaces") == base_url + "trees/tree/my%20tag%20with%20spaces"
-    assert _sanitize_url(base_url + "trees/tree/{}", "my/tag with mixed.types") == base_url + "trees/tree/my%2Ftag%20with%20mixed.types"
+    assert _sanitize_url(base_url + "/trees/tree") == base_url + "/trees/tree"
+    assert _sanitize_url(base_url + "/trees/tree/{}", "my tag with spaces") == base_url + "/trees/tree/my%20tag%20with%20spaces"
+    assert _sanitize_url(base_url + "/trees/tree/{}", "my/tag with mixed.types") == base_url + "/trees/tree/my%2Ftag%20with%20mixed.types"
     assert (
-        _sanitize_url(base_url + "trees/tree/{}/{}", "tag/name", "other/string@with-at")
-        == base_url + "trees/tree/tag%2Fname/other%2Fstring%40with-at"
+        _sanitize_url(base_url + "/trees/tree/{}/{}", "tag/name", "other/string@with-at")
+        == base_url + "/trees/tree/tag%2Fname/other%2Fstring%40with-at"
     )


### PR DESCRIPTION
In May the Spark implementation and the UI were fixed in order to support arbitrary strings like "my/branch" as branch names:

- https://github.com/projectnessie/nessie/issues/6802
- https://github.com/projectnessie/nessie/issues/6803

But not `pynessie v0.64.2` fails when invoking `.list_keys(ref='big/test')`:

```
Entity not found at https://..../api/v1/trees/tree/big/test/entries?maxRecords=500
```

In this PR I'm using `urllib.parse.quote_plus` for encoding all user's inputs that dynamically compose the final URL.