### PR TITLE
upgrade pylint to 3.0.2

### DIFF
--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -26,5 +26,5 @@ flake8-isort==6.1.1
 isort==5.12.0
 mypy==1.7.1
 pytest-mypy==0.10.3
-pylint==2.17.7
-pylintfileheader==0.3.3
+pylint==3.0.2
+pylintfileheader==1.0.0


### PR DESCRIPTION
also pylintfileheader to 1.0.0 for compatibility

upgrading individually causes conflicts:
```
The conflict is caused by:
    The user requested pylint==3.0.2
    pylintfileheader 0.3.3 depends on pylint<3.0
```
or
```
 The conflict is caused by:
    The user requested pylint==2.17.7
    pylintfileheader 1.0.0 depends on pylint<4.0 and >=3.0
```