### PR TITLE
Add "Namespace" model

### DIFF
--- a/pynessie/model.py
+++ b/pynessie/model.py
@@ -137,7 +137,7 @@ IcebergViewSchema = desert.schema_class(IcebergView)
 class Namespace(Content):
     """Dataclass for Nessie Namespace."""
 
-    elements: list[str] = desert.ib(fields.List(fields.Str(data_key="elements")))
+    elements: List[str] = desert.ib(fields.List(fields.Str(data_key="elements")))
 
     def pretty_print(self) -> str:
         """Print out for cli."""

--- a/pynessie/model.py
+++ b/pynessie/model.py
@@ -32,10 +32,10 @@ __RE_REFERENCE_WITH_HASH: re.Pattern = re.compile(f"^({__RE_REFERENCE_NAME_RAW})
 
 DETACHED_REFERENCE_NAME = "DETACHED"
 
-CONTENT_ICEBERG_TABLE_NAME = "ICEBERG_TABLE"
-CONTENT_DELTA_LAKE_TABLE_NAME = "DELTA_LAKE_TABLE"
-CONTENT_ICEBERG_VIEW_NAME = "ICEBERG_VIEW"
-CONTENT_NAMESPACE_NAME = "NAMESPACE"
+ICEBERG_TABLE_TYPE_NAME = "ICEBERG_TABLE"
+DELTA_LAKE_TABLE_TYPE_NAME = "DELTA_LAKE_TABLE"
+ICEBERG_VIEW_TYPE_NAME = "ICEBERG_VIEW"
+NAMESPACE_NAME = "NAMESPACE"
 
 
 def is_valid_reference_name(ref: str) -> bool:
@@ -151,22 +151,22 @@ class ContentSchema(OneOfSchema):
     """Schema for Nessie Content."""
 
     type_schemas = {
-        CONTENT_ICEBERG_TABLE_NAME: IcebergTableSchema,
-        CONTENT_DELTA_LAKE_TABLE_NAME: DeltaLakeTableSchema,
-        CONTENT_ICEBERG_VIEW_NAME: IcebergViewSchema,
-        CONTENT_NAMESPACE_NAME: NamespaceSchema,
+        ICEBERG_TABLE_TYPE_NAME: IcebergTableSchema,
+        DELTA_LAKE_TABLE_TYPE_NAME: DeltaLakeTableSchema,
+        ICEBERG_VIEW_TYPE_NAME: IcebergViewSchema,
+        NAMESPACE_NAME: NamespaceSchema,
     }
 
     def get_obj_type(self, obj: Content) -> str:
         """Returns the object type based on its class."""
         if isinstance(obj, IcebergTable):
-            return CONTENT_ICEBERG_TABLE_NAME
+            return ICEBERG_TABLE_TYPE_NAME
         if isinstance(obj, DeltaLakeTable):
-            return CONTENT_DELTA_LAKE_TABLE_NAME
+            return DELTA_LAKE_TABLE_TYPE_NAME
         if isinstance(obj, IcebergView):
-            return CONTENT_ICEBERG_VIEW_NAME
+            return ICEBERG_VIEW_TYPE_NAME
         if isinstance(obj, Namespace):
-            return CONTENT_NAMESPACE_NAME
+            return NAMESPACE_NAME
 
         raise ValueError("Unknown object type: {}".format(obj.__class__.__name__))
 

--- a/pynessie/model.py
+++ b/pynessie/model.py
@@ -141,7 +141,8 @@ class Namespace(Content):
 
     def pretty_print(self) -> str:
         """Print out for cli."""
-        return "Namespace"
+        elements = "\n\t\t".join(self.elements)
+        return "Namespace\n\telements: {}".format(elements)
 
 
 NamespaceSchema = desert.schema_class(Namespace)

--- a/pynessie/model.py
+++ b/pynessie/model.py
@@ -32,6 +32,11 @@ __RE_REFERENCE_WITH_HASH: re.Pattern = re.compile(f"^({__RE_REFERENCE_NAME_RAW})
 
 DETACHED_REFERENCE_NAME = "DETACHED"
 
+CONTENT_ICEBERG_TABLE_NAME = "ICEBERG_TABLE"
+CONTENT_DELTA_LAKE_TABLE_NAME = "DELTA_LAKE_TABLE"
+CONTENT_ICEBERG_VIEW_NAME = "ICEBERG_VIEW"
+CONTENT_NAMESPACE_NAME = "NAMESPACE"
+
 
 def is_valid_reference_name(ref: str) -> bool:
     """Checks whether 'ref' is a valid reference name."""
@@ -128,23 +133,40 @@ class IcebergView(Content):
 IcebergViewSchema = desert.schema_class(IcebergView)
 
 
+@attr.dataclass
+class Namespace(Content):
+    """Dataclass for Nessie Namespace."""
+
+    elements: list[str] = desert.ib(fields.List(fields.Str(data_key="elements")))
+
+    def pretty_print(self) -> str:
+        """Print out for cli."""
+        return "Namespace"
+
+
+NamespaceSchema = desert.schema_class(Namespace)
+
+
 class ContentSchema(OneOfSchema):
     """Schema for Nessie Content."""
 
     type_schemas = {
-        "ICEBERG_TABLE": IcebergTableSchema,
-        "DELTA_LAKE_TABLE": DeltaLakeTableSchema,
-        "ICEBERG_VIEW": IcebergViewSchema,
+        CONTENT_ICEBERG_TABLE_NAME: IcebergTableSchema,
+        CONTENT_DELTA_LAKE_TABLE_NAME: DeltaLakeTableSchema,
+        CONTENT_ICEBERG_VIEW_NAME: IcebergViewSchema,
+        CONTENT_NAMESPACE_NAME: NamespaceSchema,
     }
 
     def get_obj_type(self, obj: Content) -> str:
         """Returns the object type based on its class."""
         if isinstance(obj, IcebergTable):
-            return "ICEBERG_TABLE"
+            return CONTENT_ICEBERG_TABLE_NAME
         if isinstance(obj, DeltaLakeTable):
-            return "DELTA_LAKE_TABLE"
+            return CONTENT_DELTA_LAKE_TABLE_NAME
         if isinstance(obj, IcebergView):
-            return "ICEBERG_VIEW"
+            return CONTENT_ICEBERG_VIEW_NAME
+        if isinstance(obj, Namespace):
+            return CONTENT_NAMESPACE_NAME
 
         raise ValueError("Unknown object type: {}".format(obj.__class__.__name__))
 

--- a/pynessie/model.py
+++ b/pynessie/model.py
@@ -35,7 +35,7 @@ DETACHED_REFERENCE_NAME = "DETACHED"
 ICEBERG_TABLE_TYPE_NAME = "ICEBERG_TABLE"
 DELTA_LAKE_TABLE_TYPE_NAME = "DELTA_LAKE_TABLE"
 ICEBERG_VIEW_TYPE_NAME = "ICEBERG_VIEW"
-NAMESPACE_NAME = "NAMESPACE"
+NAMESPACE_TYPE_NAME = "NAMESPACE"
 
 
 def is_valid_reference_name(ref: str) -> bool:
@@ -155,7 +155,7 @@ class ContentSchema(OneOfSchema):
         ICEBERG_TABLE_TYPE_NAME: IcebergTableSchema,
         DELTA_LAKE_TABLE_TYPE_NAME: DeltaLakeTableSchema,
         ICEBERG_VIEW_TYPE_NAME: IcebergViewSchema,
-        NAMESPACE_NAME: NamespaceSchema,
+        NAMESPACE_TYPE_NAME: NamespaceSchema,
     }
 
     def get_obj_type(self, obj: Content) -> str:
@@ -167,7 +167,7 @@ class ContentSchema(OneOfSchema):
         if isinstance(obj, IcebergView):
             return ICEBERG_VIEW_TYPE_NAME
         if isinstance(obj, Namespace):
-            return NAMESPACE_NAME
+            return NAMESPACE_TYPE_NAME
 
         raise ValueError("Unknown object type: {}".format(obj.__class__.__name__))
 


### PR DESCRIPTION
While playing with the SDK, I needed to create a new Namespace, but the model was missing.

This PR will enable users to perform:
```python
new_content = pynessie.model.Namespace(None, content_key.elements)

self.nessie.commit(
    nessie_identifier.ref,
    old_ref.hash_,
    f'CREATE NAMESPACE {namespace}',
    'admin',
    pynessie.model.Put(content_key, new_content),
)
```

I've also remapped the supported content_types into costants, it will make easier to compose query_filters like:
```python
kinds = [
    pynessie.model.CONTENT_ICEBERG_TABLE_NAME, 
    pynessiel.model.CONTENT_DELTA_LAKE_TABLE_NAME,
]
query_filter = f'entry.contentType in {kinds}'
```