### PR TITLE
Ignore CVE-2018-20225 for `pip` in safety + pin `python-dateutil`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ confuse==2.0.1
 desert==2022.9.22
 marshmallow==3.21.2
 marshmallow_oneofschema==3.0.1
-python-dateutil>=2.8.0
+python-dateutil==2.9.0.post0
 requests==2.31.0
 requests-aws4auth==1.2.3
 simplejson==3.19.2

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ deps = safety
 commands =
     # using separate env because of https://github.com/pyupio/safety/issues/455
     # note that requirements_lint.txt imports all other requirement files
-    safety check --file requirements_lint.txt
+    safety check --file requirements_lint.txt --ignore 67599
 
 
 [testenv:docs]


### PR DESCRIPTION
Recent pynessie CI runs fail with the following safety-check error.

```
  -> Vulnerability found in pip version 24.0
     Vulnerability ID: 67599
     Affected spec: >=0
     ADVISORY: ** DISPUTED ** An issue was discovered in pip (all
     versions) because it installs the version with the highest version...
     CVE-2018-20225
     For more information about this vulnerability, visit
     https://data.safetycli.com/v/67599/97c
```

Also pins `python-dateutil`

```
    * Warning: python-dateutil is unpinned. Safety by default does not report on
      potential vulnerabilities in unpinned packages. It is recommended to pin
      your dependencies unless this is a library meant for distribution. To learn
      more about reporting these, specifier range handling, and options for
      scanning unpinned packages visit https://docs.pyup.io/docs/safety-range-
      specs
```