### PR TITLE
Update Python dependency baseline

### DIFF
--- a/.github/actions/dev-tool-python/action.yml
+++ b/.github/actions/dev-tool-python/action.yml
@@ -3,15 +3,20 @@ description: 'Setup Python runtime environment'
 inputs:
   python-version:
     required: true
-    default: '3.9'
-    description: 'The Python version, defaults to 3.9'
+    default: '3.11'
+    description: 'The Python version, defaults to 3.11'
+  allow-prereleases:
+    required: false
+    default: 'false'
+    description: 'Allow pre-release Python versions.'
 runs:
   using: "composite"
   steps:
     - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
+        allow-prereleases: ${{ inputs.allow-prereleases }}
     - name: Install dependencies
       shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,13 +41,14 @@ jobs:
       NESSIE_TEST_IMAGE: 'ghcr.io/projectnessie/nessie:latest'
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12'] # 3.8 first, it has "all the tox envs"
+        python-version: ['3.11', '3.12', '3.13', '3.14', '3.15'] # 3.11 first, it has lint and safety
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v6
       - name: Setup Python
         uses: ./.github/actions/dev-tool-python
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: ${{ matrix.python-version == '3.15' }}
       - name: Test with tox
         run: tox
       - name: Just show images
@@ -63,11 +64,11 @@ jobs:
             - 'ghcr.io/projectnessie/nessie-unstable:latest'
             - 'ghcr.io/projectnessie/nessie:0.63.0'
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v6
       - name: Setup Python
         uses: ./.github/actions/dev-tool-python
         with:
-          python-version: 3.8
+          python-version: 3.11
       - name: Test with tox
         env:
           NESSIE_TEST_IMAGE: ${{ matrix.nessie-image }}

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -58,14 +58,14 @@ jobs:
 
     ### BEGIN runner setup
     - name: Checkout
-      uses: actions/checkout@v4.1.7
+      uses: actions/checkout@v6
       with:
         ref: ${{ env.RELEASE_FROM }}
         fetch-depth: '0'
     - name: Setup Python
       uses: ./.github/actions/dev-tool-python
       with:
-        python-version: '3.8'
+        python-version: '3.11'
     - name: Install Python dependencies
       run: |
         python3 -m pip install --upgrade pip

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -73,12 +73,12 @@ jobs:
 
     ### BEGIN runner setup
     - name: Checkout
-      uses: actions/checkout@v4.1.7
+      uses: actions/checkout@v6
       if: ${{ github.event_name == 'push' }}
       with:
         fetch-depth: '0'
     - name: Checkout
-      uses: actions/checkout@v4.1.7
+      uses: actions/checkout@v6
       if: ${{ github.event_name == 'workflow_dispatch' }}
       with:
         fetch-depth: '0'
@@ -86,7 +86,7 @@ jobs:
     - name: Setup Python
       uses: ./.github/actions/dev-tool-python
       with:
-        python-version: '3.8'
+        python-version: '3.11'
     - name: Install Python dependencies
       run: |
         python3 -m pip install --upgrade pip

--- a/.pylintrc
+++ b/.pylintrc
@@ -55,11 +55,7 @@ persistent=yes
 
 # Min Python version to use for version dependend checks. Will default to the
 # version used to run pylint.
-py-version=3.8
-
-# When enabled, pylint would attempt to guess common misconfiguration and emit
-# user-friendly hints instead of false-positive error messages.
-suggestion-mode=yes
+py-version=3.11
 
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
@@ -83,6 +79,7 @@ confidence=
 # --disable=W".
 disable=unused-argument,
         too-many-arguments,
+        too-many-positional-arguments,
         unnecessary-pass,
         too-few-public-methods,
         fixme,

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -121,7 +121,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 3.8 up to 3.12. Check
+3. The pull request should work for Python 3.11 up to 3.15. Check
    the pull request status and make sure that the tests pass for all
    supported Python versions.
 

--- a/pynessie/__init__.py
+++ b/pynessie/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 """Top-level package for Python API and CLI for Nessie."""
+
 import os
 from typing import Optional
 

--- a/pynessie/auth/aws.py
+++ b/pynessie/auth/aws.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 """Use AWS4Auth and botocore to fetch credentials and sign requests."""
+
 from typing import Optional
 
 from botocore.credentials import get_credentials

--- a/pynessie/auth/bearer.py
+++ b/pynessie/auth/bearer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 """Bearer auth for Nessie client."""
+
 from requests import models
 from requests.auth import AuthBase
 

--- a/pynessie/cli.py
+++ b/pynessie/cli.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 """Console script for nessie_client."""
+
 import sys
 from typing import Any
 

--- a/pynessie/cli_common_context.py
+++ b/pynessie/cli_common_context.py
@@ -14,6 +14,7 @@
 #
 
 """Cli Common context functions that can be used by CLI commands/groups."""
+
 from typing import Any, Dict, List, Mapping, Tuple
 
 import attr

--- a/pynessie/client/_endpoints.py
+++ b/pynessie/client/_endpoints.py
@@ -15,12 +15,12 @@
 
 """Direct API operations on Nessie with requests."""
 
+import json as jsonlib
 import os
 from typing import Any, Optional, Union, cast
 from urllib.parse import quote
 
 import requests
-import simplejson as jsonlib
 from requests.auth import AuthBase
 
 from pynessie.error import _create_exception

--- a/pynessie/commands/cherry_pick.py
+++ b/pynessie/commands/cherry_pick.py
@@ -64,10 +64,8 @@ def cherry_pick(ctx: ContextObject, ref: str, force: bool, expected_hash: str, s
     with main branch's expected hash '12345678abcdef'
     """
     if not force and not expected_hash:
-        raise UsageError(
-            """Either condition or force must be set. Condition should be set to a valid hash for concurrency
-            control or force to ignore current state of Nessie Store."""
-        )
+        raise UsageError("""Either condition or force must be set. Condition should be set to a valid hash for concurrency
+            control or force to ignore current state of Nessie Store.""")
     merge_response = ctx.nessie.cherry_pick(ref, source_ref, expected_hash, *hashes)
     if ctx.json:
         click.echo(MergeResponseSchema().dumps(merge_response))

--- a/pynessie/commands/content/commit.py
+++ b/pynessie/commands/content/commit.py
@@ -14,6 +14,7 @@
 #
 
 """Contents Commit Command CLI."""
+
 from json import JSONDecodeError
 from typing import List, Optional
 
@@ -127,6 +128,7 @@ def _get_edit_content_operations(
             continue
 
         # If the user has an invalid JSON, we raise an Error
+        assert content_json is not None
         try:
             content_new = ContentSchema().loads(content_json)
         except JSONDecodeError as e:

--- a/pynessie/commands/content/view.py
+++ b/pynessie/commands/content/view.py
@@ -14,6 +14,7 @@
 #
 
 """Contents View Command CLI."""
+
 from typing import List
 
 import click

--- a/pynessie/commands/merge.py
+++ b/pynessie/commands/merge.py
@@ -65,10 +65,8 @@ def merge(ctx: ContextObject, ref: str, force: bool, expected_hash: str, hash_on
         nessie merge -f -b main dev -> forcefully merge dev to a branch named main
     """
     if not force and not expected_hash:
-        raise UsageError(
-            """Either condition or force must be set. Condition should be set to a valid hash for concurrency
-            control or force to ignore current state of Nessie Store."""
-        )
+        raise UsageError("""Either condition or force must be set. Condition should be set to a valid hash for concurrency
+            control or force to ignore current state of Nessie Store.""")
     merge_response = ctx.nessie.merge(from_ref, ref, hash_on_ref, expected_hash)
     if ctx.json:
         click.echo(MergeResponseSchema().dumps(merge_response))

--- a/pynessie/conf/__init__.py
+++ b/pynessie/conf/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 """Config classes for nessie client."""
+
 from io import StringIO
 
 import confuse

--- a/pynessie/conf/config_command.py
+++ b/pynessie/conf/config_command.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 #
 """Execute config command from cli."""
-from typing import Optional, Union, cast
+
+from typing import Any, Optional, Union, cast
 
 import click
-import confuse
 
 from pynessie.conf.config_parser import build_config
 from pynessie.conf.io import write_to_file
@@ -44,11 +44,11 @@ def process(
         write_to_file(config)
         return ""
     if unset_op:
-        config = build_config()
+        unset_config: Any = build_config()
         for k in unset_op.split("."):
-            config = config[k]
-        config.set(None)
-        write_to_file(config.root())
+            unset_config = unset_config[k]
+        unset_config.set(None)
+        write_to_file(unset_config.root())
         return ""
     if list_op:
         config = build_config()
@@ -74,8 +74,8 @@ def _set_type(key: str, type_str: Optional[str]) -> Union[bool, int, str]:
     return key
 
 
-def _get_key(key: str) -> confuse.Configuration:
-    config = build_config()
+def _get_key(key: str) -> Any:
+    config: Any = build_config()
     for i in key.split("."):
         if not i:
             continue

--- a/pynessie/conf/config_parser.py
+++ b/pynessie/conf/config_parser.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 """Parser for confuse Configuration object."""
+
 import os
 from typing import Optional
 

--- a/pynessie/conf/io.py
+++ b/pynessie/conf/io.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 """IO methods to read and write config."""
+
 import os
 
 import confuse

--- a/pynessie/decorators.py
+++ b/pynessie/decorators.py
@@ -14,6 +14,7 @@
 #
 
 """Top-level decorators."""
+
 import functools
 import sys
 from typing import Any, Callable

--- a/pynessie/error.py
+++ b/pynessie/error.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 #
 """Nessie Exceptions."""
-from typing import Optional
 
-import simplejson as json
+import json
+from typing import Optional
 
 
 class NessieInvalidUsageException(Exception):

--- a/pynessie/model.py
+++ b/pynessie/model.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 """Nessie Data objects."""
+
 import re
 from datetime import datetime
 from typing import List, Optional, Tuple

--- a/pynessie/types.py
+++ b/pynessie/types.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 """Custom types that can be used with click."""
+
 from typing import Any, Optional
 
 import click

--- a/pynessie/utils/expression_util.py
+++ b/pynessie/utils/expression_util.py
@@ -14,7 +14,6 @@
 
 """The purpose of this module is to provide different functions that can produce CEL Expressions based on given filtering parameters."""
 
-
 from datetime import timezone
 from typing import List, Optional
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,14 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-attrs==24.3.0
-botocore==1.36.26
-Click==8.1.8
-confuse==2.0.1
+attrs==26.1.0
+botocore==1.43.18
+Click==8.4.1
+confuse==2.2.0
 desert==2022.9.22
-marshmallow==3.22.0
-marshmallow_oneofschema==3.0.1
+marshmallow==3.26.2
+marshmallow_oneofschema==3.2.0
 python-dateutil==2.9.0.post0
-requests==2.32.3
-requests-aws4auth==1.3.1
-simplejson==3.20.1
+requests==2.33.0
+requests-aws4auth==1.3.2

--- a/requirements_basedev.txt
+++ b/requirements_basedev.txt
@@ -14,17 +14,17 @@
 # limitations under the License.
 #
 
-# Base dev dependencies, compatible with Python 3.8+
+# Base dev dependencies, compatible with Python 3.11+
 -r requirements.txt
 assertpy==1.1
 bump2version==1.0.1
-coverage==7.6.1
-pip==24.3.1
-pytest==8.3.4
-pytest-cov==5.0.0
-pytest-mock==3.14.0
-testcontainers==3.7.1
-tox==4.24.1
-twine==5.1.1
-watchdog==4.0.2
-wheel==0.45.1
+coverage==7.14.1
+pip==26.1
+pytest==9.0.3
+pytest-cov==7.1.0
+pytest-mock==3.15.1
+testcontainers==4.14.2
+tox==4.55.0
+twine==6.2.0
+watchdog==6.0.0
+wheel==0.46.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-# Common dev dependencies, compatible with Python 3.8+
+# Common dev dependencies, compatible with Python 3.12+
 -r requirements_basedev.txt
-Sphinx==7.1.2
-sphinx-autodoc-typehints==2.0.1
+Sphinx==9.1.0
+sphinx-autodoc-typehints==3.10.4

--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -13,18 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
--r requirements_dev.txt
-bandit==1.7.10
-black==24.8.0
-flake8==7.1.2
-flake8-annotations==3.1.1
+-r requirements_basedev.txt
+bandit==1.9.4
+black==26.3.1
+flake8==7.3.0
+flake8-annotations==3.2.0
 flake8-bandit==4.1.1
-flake8-black==0.3.6
-flake8-bugbear==24.12.12
+flake8-black==0.4.0
+flake8-bugbear==25.11.29
 flake8-docstrings==1.7.0
-flake8-isort==6.1.1
-isort==5.13.2
-mypy==1.14.1
-pytest-mypy==0.10.3
-pylint==3.2.7
-pylintfileheader==1.0.0
+flake8-isort==7.0.0
+isort==8.0.1
+mypy==2.1.0
+pytest-mypy==1.0.1
+pylint==4.0.5
+pylintfileheader==1.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ universal = 1
 [flake8]
 exclude = docs
 select = ANN,B,B9,B950,BLK,C,D,E,F,I,S,W
-ignore = ANN101,ANN102,ANN401,S101,D412,W503
+ignore = ANN101,ANN102,ANN401,S101,D412,W503,B042
 max-line-length = 140
 max-complexity = 10
 application-import-names = pynessie,tests

--- a/setup.py
+++ b/setup.py
@@ -29,31 +29,30 @@ requirements = [
     "attrs",  # features we use are not regularly changing
     "botocore",  # features we use are not regularly changing
     "Click<9.0.0,>6.0.0",  # pinning to 7.x or 8.x as we have used w/ both
-    "confuse==2.0.1",  # important for config so don't change w/o testing
+    "confuse==2.2.0",  # important for config so don't change w/o testing
     "desert",  # features we use are not regularly changing
     "marshmallow",  # features we use are not regularly changing
     "marshmallow_oneofschema",  # features we use are not regularly changing
     "python-dateutil",  # stable
     "requests",  # stable
     "requests-aws4auth",  # stable
-    "simplejson",  # stable
 ]
 
 setup(
     author="Ryan Murray",
     author_email="nessie-release-builder@dremio.com",
-    python_requires=">=3.8",
+    python_requires=">=3.11",
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
+        "Programming Language :: Python :: 3.15",
     ],
     description="Project Nessie: Transactional Catalog for Data Lakes with Git-like semantics",
     entry_points={

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,11 +21,10 @@ from typing import List, Optional
 
 import attr
 import pytest
-import requests
 from assertpy import assert_that
 from click.testing import CliRunner, Result
 from testcontainers.core.generic import DockerContainer
-from testcontainers.core.waiting_utils import wait_container_is_ready
+from testcontainers.core.wait_strategies import HttpWaitStrategy
 
 from pynessie import cli
 from pynessie.model import Content, ContentSchema, ReferenceSchema
@@ -42,6 +41,7 @@ class NessieContainer(DockerContainer):
         """Nessie test container constructor using the Nessie image tagged as 'latest'."""
         super().__init__(image=image)
         self.with_exposed_ports(NessieContainer.NESSIE_PORT)
+        self.waiting_for(HttpWaitStrategy(NessieContainer.NESSIE_PORT).for_status_code(200))
 
     def get_base_url(self) -> str:
         """Get the root Nessie HTTP URL."""
@@ -52,17 +52,6 @@ class NessieContainer(DockerContainer):
     def get_url(self, api_version: int = 1) -> str:
         """Retrieve the Nessie API URL for the given Nessie API version, defaults to 1."""
         return f"{self.get_base_url()}api/v{api_version}"
-
-    @wait_container_is_ready(requests.exceptions.ConnectionError, requests.exceptions.ReadTimeout)
-    def _connect(self) -> None:
-        response = requests.get(f"{self.get_base_url()}", timeout=1)
-        response.raise_for_status()
-
-    def start(self) -> "NessieContainer":
-        """Starts the Nessie container, waits until Nessie is ready."""
-        super().start()
-        self._connect()
-        return self
 
 
 @attr.dataclass
@@ -128,7 +117,7 @@ def execute_cli_command_raw(args: List[str], input_data: Optional[str] = None, r
 
 def execute_cli_command(args: List[str], input_data: Optional[str] = None, ret_val: int = 0) -> str:
     """Execute a Nessie CLI command and return its STDOUT."""
-    return execute_cli_command_raw(args, input_data=input_data, ret_val=ret_val).stdout
+    return execute_cli_command_raw(args, input_data=input_data, ret_val=ret_val).output
 
 
 def ref_hash(ref: str) -> str:

--- a/tests/test_nessie_auth.py
+++ b/tests/test_nessie_auth.py
@@ -65,14 +65,12 @@ def test_aws_auth() -> None:
 def test_aws_auth_profile(tmp_path: Path) -> None:
     """Makes sure the request is signed according to AWS auth requirements."""
     aws_credentials = tmp_path / "aws.config"
-    aws_credentials.write_text(
-        """
+    aws_credentials.write_text("""
 [test1]
 aws_access_key_id=test1_key
 aws_secret_access_key=test1_secret
 aws_session_token=test1_session
-    """
-    )
+    """)
     config = build_config({"auth.type": "aws", "auth.region": "us-west-2", "auth.profile": "test1"})
     os.environ["AWS_SHARED_CREDENTIALS_FILE"] = str(aws_credentials)
     auth = setup_auth(config)

--- a/tests/test_nessie_cli.py
+++ b/tests/test_nessie_cli.py
@@ -13,12 +13,13 @@
 # limitations under the License.
 #
 """Tests for `pynessie` package."""
+
 import itertools
+import json as simplejson
 from typing import List
 
 import confuse
 import pytest
-import simplejson
 from assertpy import assert_that
 
 from pynessie import __version__
@@ -48,7 +49,7 @@ from .conftest import (
 @pytest.mark.nessieserver
 def test_command_line_interface() -> None:
     """Test the CLI."""
-    assert "Usage: nessie" in execute_cli_command([])
+    assert "Usage: nessie" in execute_cli_command([], ret_val=2)
     assert "Usage: nessie" in execute_cli_command(["--help"])
     assert __version__ in execute_cli_command(["--version"])
     references = ReferenceSchema().loads(execute_cli_command(["--json", "branch", "-l"]), many=True)

--- a/tests/test_nessie_cli_content.py
+++ b/tests/test_nessie_cli_content.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for `content CLI command`."""
+
+import json as simplejson
 from typing import List, Optional
 
 import pytest
-import simplejson
 from assertpy import assert_that
 
 from pynessie.model import (

--- a/tests/test_nessie_client.py
+++ b/tests/test_nessie_client.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 """Tests for `pynessie` package."""
+
 import pytest
 
 from pynessie import init

--- a/tests/test_nessie_models.py
+++ b/tests/test_nessie_models.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 """Test Nessie models."""
+
 from assertpy import assert_that
 
 from pynessie.model import ContentKey

--- a/tools/generate_docs.py
+++ b/tools/generate_docs.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 """Generate pynessie docs script."""
+
 import os
 from pathlib import Path
 from typing import IO, List, Optional

--- a/tox.ini
+++ b/tox.ini
@@ -15,16 +15,16 @@
 #
 
 [tox]
-envlist = py38, py39, py310, py311, py312, format, lint, safety, docs, docs_sync_check
+envlist = py311, py312, py313, py314, py315, format, lint, safety, docs, docs_sync_check
 
 [gh-actions]
 python =
     # docs needs to run before docs_sync_check
-    3.8: py38, lint, safety, docs, docs_sync_check
-    3.9: py39
-    3.10: py310
-    3.11: py311
-    3.12: py312
+    3.11: py311, lint, safety
+    3.12: py312, docs, docs_sync_check
+    3.13: py313
+    3.14: py314
+    3.15: py315
 
 
 [testenv:format]
@@ -53,7 +53,7 @@ basepython = python
 deps = safety
 commands =
     # using separate env because of https://github.com/pyupio/safety/issues/455
-    # note that requirements_lint.txt imports all other requirement files
+    # note that requirements_lint.txt imports the base requirement files
     safety check --file requirements_lint.txt --ignore 67599
 
 
@@ -76,8 +76,8 @@ commands =
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}
-passenv = TOXENV,CI,CODECOV_*,NESSIE_TEST_IMAGE
+passenv = TOXENV,CI,CODECOV_*,DOCKER_*,TESTCONTAINERS_*,NESSIE_TEST_IMAGE
 deps =
     -r{toxinidir}/requirements_basedev.txt
 commands =
-    pytest --cov=pynessie --basetemp={envtmpdir} --cov-report=xml
+    pytest --cov=pynessie --basetemp={envtmpdir} --cov-report=xml {posargs}


### PR DESCRIPTION
Drop support for Python versions older than 3.11 so the project can move to current dependency majors and test against Python 3.15. Update tox and GitHub Actions to run the supported 3.11-3.15 matrix, including prerelease setup for 3.15 and newer checkout/setup-python actions.

Refresh runtime, test, lint, and docs pins together because the open dependency PRs are interdependent once old Python support is removed. Split lint from docs dependencies so Sphinx 9's Python 3.12 floor does not prevent linting on Python 3.11.

Apply the small compatibility migrations needed by the new stack: use stdlib json instead of simplejson for Python 3.15 compatibility, pass Docker/Testcontainers environment through tox, move the Nessie test container to testcontainers v4 HTTP wait strategies, and adjust tests for Click 8.4 stderr and root-command exit behavior.